### PR TITLE
fix: Make compatible with paragonie/ecc v2.5.0

### DIFF
--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Signature/Signature.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Signature/Signature.php
@@ -85,4 +85,12 @@ class Signature extends Serializable implements SignatureInterface, \Mdanter\Ecc
     {
         return (new DerSignatureSerializer($this->ecAdapter))->serialize($this);
     }
+
+    /**
+     * @return string
+     */
+    public function getSignatureType(): string
+    {
+        return 'ecdsa';
+    }
 }


### PR DESCRIPTION
See #15, implements `getSignatureType()`